### PR TITLE
Get spreadsheet indicator order

### DIFF
--- a/src/main/java/br/com/dextra/dexboard/json/ProjetoJson.java
+++ b/src/main/java/br/com/dextra/dexboard/json/ProjetoJson.java
@@ -39,15 +39,6 @@ public class ProjetoJson {
 		}
 	}
 
-	private void ordenaIndicadores() {
-		Collections.sort(this.indicadores, new Comparator<IndicadorJson>() {
-			@Override
-			public int compare(IndicadorJson i1, IndicadorJson i2) {
-				return i1.getNome().compareToIgnoreCase(i2.getNome());
-			}
-		});
-	}
-
 	public boolean getAtrasado() {
 		return atrasado;
 	}

--- a/src/main/java/br/com/dextra/dexboard/json/ProjetoJson.java
+++ b/src/main/java/br/com/dextra/dexboard/json/ProjetoJson.java
@@ -25,7 +25,6 @@ public class ProjetoJson {
 		this.projeto = projeto;
 
 		inicializaIndicadores();
-		ordenaIndicadores();
 
 		this.classificacao = defineClassificacao();
 		this.atrasado = defineAtrasado();


### PR DESCRIPTION
Prevalece a ordem que está cadastrada na planilha.

Essa alteração tem o intuido de não confundir na hora de preencher o dexboard, visto que vamos acrescentar mais indicadores.